### PR TITLE
Fixed bot crash when no database is avaible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,6 +399,9 @@ FodyWeavers.xsd
 
 # Database
 *.db
+*.db-shm
+*.db-wal
+
 
 # Token
 token.txt

--- a/mini-bots/Database/Database.cs
+++ b/mini-bots/Database/Database.cs
@@ -41,6 +41,7 @@ namespace MiniBots
         public DatabaseManager()
         {
             _context = new MiniBotsContext();
+            _context.Database.EnsureCreated();
         }
 
         public MiniBot? GetMiniBotByName(string name)
@@ -48,6 +49,11 @@ namespace MiniBots
             // Select all records using a LINQ query
             List<MiniBot> miniBots = [.. _context.MiniBots.Where(miniBot => miniBot.Name == name)];
 
+            if (miniBots.Count == 0)
+            {
+                return null;
+            }
+            
             return miniBots[0];
         }
 


### PR DESCRIPTION
Fixed issue where bot would crash since the database tables did not exists on first startup.

Also fixed issue where function would assume entry 0 in array was present that would also cause it to crash. 